### PR TITLE
handle multiple blocking client response

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ Run MEV-Boost pointed at a Goerli relay and relay-proxy:
 ### Max-profit
 Run MEV-Boost pointed at a mainnet max profit relay and relay-proxy running as local host:
 
-``./mev-boost -relay-check -relays https://0x8b5d2e73e2a3a55c6c87b8b6eb92e0149a125c852751db1422fa951e42a09b82c142c3ea98d0d9930b056a3bc9896b8f@bloxroute.max-profit.blxrbdn.com,https://0x8b5d2e73e2a3a55c6c87b8b6eb92e0149a125c852751db1422fa951e42a09b82c142c3ea98d0d9930b056a3bc9896b8f@relay-proxy.blxrbdn.com:18550 &
+``./mev-boost -relay-check -relays http://0x8b5d2e73e2a3a55c6c87b8b6eb92e0149a125c852751db1422fa951e42a09b82c142c3ea98d0d9930b056a3bc9896b8f@bloxroute.max-profit.blxrbdn.com,http://0x8b5d2e73e2a3a55c6c87b8b6eb92e0149a125c852751db1422fa951e42a09b82c142c3ea98d0d9930b056a3bc9896b8f@relay-proxy.blxrbdn.com:18550 &
 ``
 ### Regulated
 Run MEV-Boost pointed at a mainnet regulated relay and relay-proxy running as local host:
 
-``./mev-boost -relay-check -relays https://0xb0b07cd0abef743db4260b0ed50619cf6ad4d82064cb4fbec9d3ec530f7c5e6793d9f286c4e082c0244ffb9f2658fe88@bloxroute.regulated.blxrbdn.com,https://0xb0b07cd0abef743db4260b0ed50619cf6ad4d82064cb4fbec9d3ec530f7c5e6793d9f286c4e082c0244ffb9f2658fe88@relay-proxy.blxrbdn.com:18551 &
+``./mev-boost -relay-check -relays http://0xb0b07cd0abef743db4260b0ed50619cf6ad4d82064cb4fbec9d3ec530f7c5e6793d9f286c4e082c0244ffb9f2658fe88@bloxroute.regulated.blxrbdn.com,http://0xb0b07cd0abef743db4260b0ed50619cf6ad4d82064cb4fbec9d3ec530f7c5e6793d9f286c4e082c0244ffb9f2658fe88@relay-proxy.blxrbdn.com:18551 &
 ``
+### Note

--- a/README.md
+++ b/README.md
@@ -85,3 +85,4 @@ Run MEV-Boost pointed at a mainnet regulated relay and relay-proxy running as lo
 ``./mev-boost -relay-check -relays http://0xb0b07cd0abef743db4260b0ed50619cf6ad4d82064cb4fbec9d3ec530f7c5e6793d9f286c4e082c0244ffb9f2658fe88@bloxroute.regulated.blxrbdn.com,http://0xb0b07cd0abef743db4260b0ed50619cf6ad4d82064cb4fbec9d3ec530f7c5e6793d9f286c4e082c0244ffb9f2658fe88@relay-proxy.blxrbdn.com:18551 &
 ``
 ### Note
+Make sure to use http instead of https while configuring mev-boost relays flag

--- a/api/server.go
+++ b/api/server.go
@@ -52,7 +52,7 @@ func (s *Server) Start() error {
 		ReadTimeout:       0,
 		ReadHeaderTimeout: 0,
 		WriteTimeout:      0,
-		IdleTimeout:       60 * time.Second,
+		IdleTimeout:       10 * time.Second,
 	}
 	err := s.server.ListenAndServe()
 	if err == http.ErrServerClosed {
@@ -63,10 +63,10 @@ func (s *Server) Start() error {
 
 func (s *Server) InitHandler() *chi.Mux {
 	handler := chi.NewRouter()
-	handler.With(s.middleWare).Get(pathStatus, s.HandleStatus)
-	handler.With(s.middleWare).Post(pathRegisterValidator, s.HandleRegistration)
-	handler.With(s.middleWare).Get(pathGetHeader, s.HandleGetHeader)
-	handler.With(s.middleWare).Post(pathGetPayload, s.HandleGetPayload)
+	handler.Get(pathStatus, s.HandleStatus)
+	handler.Post(pathRegisterValidator, s.HandleRegistration)
+	handler.Get(pathGetHeader, s.HandleGetHeader)
+	handler.Post(pathGetPayload, s.HandleGetPayload)
 	s.logger.Info("Init mev-relay-proxy")
 	return handler
 }

--- a/api/server.go
+++ b/api/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/gorilla/mux"
 	"io"
 	"net/http"
 	"time"
@@ -61,20 +62,14 @@ func (s *Server) Start() error {
 	return err
 }
 
-func (s *Server) InitHandler() *chi.Mux {
-	handler := chi.NewRouter()
-	handler.Get(pathStatus, s.HandleStatus)
-	handler.Post(pathRegisterValidator, s.HandleRegistration)
-	handler.Get(pathGetHeader, s.HandleGetHeader)
-	handler.Post(pathGetPayload, s.HandleGetPayload)
+func (s *Server) InitHandler() http.Handler {
+	handler := mux.NewRouter()
+	handler.HandleFunc(pathStatus, s.HandleStatus).Methods(http.MethodGet)
+	handler.HandleFunc(pathRegisterValidator, s.HandleRegistration).Methods(http.MethodPost)
+	handler.HandleFunc(pathGetHeader, s.HandleGetHeader).Methods(http.MethodGet)
+	handler.HandleFunc(pathGetPayload, s.HandleGetPayload).Methods(http.MethodPost)
 	s.logger.Info("Init mev-relay-proxy")
 	return handler
-}
-
-func (s *Server) middleWare(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		next.ServeHTTP(w, r)
-	})
 }
 
 func (s *Server) Stop() {

--- a/api/server.go
+++ b/api/server.go
@@ -81,7 +81,7 @@ func (s *Server) Stop() {
 func (s *Server) HandleStatus(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprintf(w, `{}`)
+	_, _ = w.Write([]byte(`{}`))
 }
 
 func (s *Server) HandleRegistration(w http.ResponseWriter, r *http.Request) {

--- a/api/server.go
+++ b/api/server.go
@@ -49,9 +49,9 @@ func (s *Server) Start() error {
 	s.server = &http.Server{
 		Addr:              s.listenAddress,
 		Handler:           s.InitHandler(),
-		ReadTimeout:       15 * time.Second,
-		ReadHeaderTimeout: 6 * time.Second,
-		WriteTimeout:      15 * time.Second,
+		ReadTimeout:       0,
+		ReadHeaderTimeout: 0,
+		WriteTimeout:      0,
 		IdleTimeout:       60 * time.Second,
 	}
 	err := s.server.ListenAndServe()

--- a/api/service.go
+++ b/api/service.go
@@ -180,9 +180,6 @@ func (s *Service) ProcessStream(ctx context.Context, client *Client) error {
 	go func() {
 		sCtx, cancel := context.WithCancel(ctx)
 		defer cancel()
-		if _, err := s.StreamHeader(sCtx, client); err != nil {
-			s.logger.Warn("failed to start streaming headers", zap.Error(err), zap.String("url", client.URL))
-		}
 		go func() {
 			stateChecker := time.NewTicker(stateCheckerInterval)
 			for {
@@ -194,6 +191,10 @@ func (s *Service) ProcessStream(ctx context.Context, client *Client) error {
 				}
 			}
 		}()
+		if _, err := s.StreamHeader(sCtx, client); err != nil {
+			s.logger.Warn("failed to start streaming headers", zap.Error(err), zap.String("url", client.URL))
+		}
+
 	}()
 	for {
 		select {
@@ -204,9 +205,6 @@ func (s *Service) ProcessStream(ctx context.Context, client *Client) error {
 			go func() {
 				sCtx, cancel := context.WithCancel(ctx)
 				defer cancel()
-				if _, err := s.StreamHeader(sCtx, client); err != nil {
-					s.logger.Warn("failed to start streaming headers", zap.Error(err), zap.String("url", client.URL))
-				}
 				go func() {
 					stateChecker := time.NewTicker(stateCheckerInterval)
 					for {
@@ -218,6 +216,10 @@ func (s *Service) ProcessStream(ctx context.Context, client *Client) error {
 						}
 					}
 				}()
+				if _, err := s.StreamHeader(sCtx, client); err != nil {
+					s.logger.Warn("failed to start streaming headers", zap.Error(err), zap.String("url", client.URL))
+				}
+
 			}()
 		case <-client.Done:
 			s.logger.Info("context done for processing requests")

--- a/api/service.go
+++ b/api/service.go
@@ -175,7 +175,6 @@ func (s *Service) waitUntilReady(ctx context.Context, client *Client) bool {
 	return true
 }
 func (s *Service) ProcessStream(ctx context.Context, client *Client) error {
-	defer client.Conn.Close()
 
 	go s.StreamHeader(ctx, client)
 	for {
@@ -230,6 +229,7 @@ StreamLoop:
 			s.logger.Warn("context cancelled, closing connection", zap.Error(ctx.Err()), zap.String("nodeID", nodeID), zap.String("reqID", id), zap.String("method", "StreamHeader"), zap.String("url", client.URL))
 			return nil, sCtx.Err()
 		default:
+			s.logger.Info("running default")
 			header, err := stream.Recv()
 			if err == io.EOF {
 				s.logger.Warn("stream received EOF", zap.Error(err), zap.String("nodeID", nodeID), zap.String("reqID", id), zap.String("url", client.URL))

--- a/api/service.go
+++ b/api/service.go
@@ -249,6 +249,9 @@ StreamLoop:
 		case <-ctx.Done():
 			s.logger.Warn("context cancelled, closing connection", zap.Error(ctx.Err()), zap.String("nodeID", nodeID), zap.String("reqID", id), zap.String("method", "StreamHeader"), zap.String("url", client.URL))
 			return nil, ctx.Err()
+		case <-stream.Context().Done():
+			s.logger.Warn("stream context cancelled, closing connection", zap.Error(stream.Context().Err()), zap.String("nodeID", nodeID), zap.String("reqID", id), zap.String("method", "StreamHeader"), zap.String("url", client.URL))
+			return nil, stream.Context().Err()
 		default:
 			s.logger.Info("running default")
 			header, err := stream.Recv()

--- a/api/service.go
+++ b/api/service.go
@@ -25,6 +25,7 @@ import (
 const (
 	connReconnectTimeout = 5 * time.Second
 	requestTimeout       = 3 * time.Second
+	stateCheckerInterval = 5 * time.Second
 )
 
 type IService interface {
@@ -183,7 +184,7 @@ func (s *Service) ProcessStream(ctx context.Context, client *Client) error {
 			s.logger.Warn("failed to start streaming headers", zap.Error(err), zap.String("url", client.URL))
 		}
 		go func() {
-			stateChecker := time.NewTicker(time.Second * 5)
+			stateChecker := time.NewTicker(stateCheckerInterval)
 			for {
 				select {
 				case <-stateChecker.C:
@@ -207,7 +208,7 @@ func (s *Service) ProcessStream(ctx context.Context, client *Client) error {
 					s.logger.Warn("failed to start streaming headers", zap.Error(err), zap.String("url", client.URL))
 				}
 				go func() {
-					stateChecker := time.NewTicker(time.Second * 10)
+					stateChecker := time.NewTicker(stateCheckerInterval)
 					for {
 						select {
 						case <-stateChecker.C:
@@ -240,12 +241,9 @@ func (s *Service) StreamHeader(ctx context.Context, client *Client) (*relaygrpc.
 		s.logger.Warn("failed to stream header", zap.Error(err), zap.String("nodeID", nodeID), zap.String("reqID", id), zap.String("url", client.URL))
 		return nil, err
 	}
-	stateChecker := time.NewTicker(time.Second * 10)
 StreamLoop:
 	for {
 		select {
-		case <-stateChecker.C:
-			s.logger.Info("stream state info", zap.String("state", client.Conn.GetState().String()))
 		case <-ctx.Done():
 			s.logger.Warn("context cancelled, closing connection", zap.Error(ctx.Err()), zap.String("nodeID", nodeID), zap.String("reqID", id), zap.String("method", "StreamHeader"), zap.String("url", client.URL))
 			return nil, ctx.Err()

--- a/api/service.go
+++ b/api/service.go
@@ -174,6 +174,7 @@ func (s *Service) StreamHeader(ctx context.Context, client *Client) (*relaygrpc.
 	var once sync.Once
 	closeDone := func() {
 		once.Do(func() {
+			s.logger.Info("calling close done once")
 			close(done)
 		})
 	}
@@ -193,7 +194,6 @@ func (s *Service) StreamHeader(ctx context.Context, client *Client) (*relaygrpc.
 			return nil, nil
 		default:
 		}
-		s.logger.Info("running default")
 		header, err := stream.Recv()
 		if err == io.EOF {
 			s.logger.Warn("stream received EOF", zap.Error(err), zap.String("nodeID", nodeID), zap.String("reqID", id), zap.String("url", client.URL))

--- a/api/service_test.go
+++ b/api/service_test.go
@@ -61,7 +61,7 @@ func TestService_RegisterValidator(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			s := &Service{
 				logger:  zap.NewNop(),
-				clients: []*Client{{"", nil, nil, nil, &mockRelayClient{RegisterValidatorFunc: tt.f}}},
+				clients: []*Client{{"", nil, &mockRelayClient{RegisterValidatorFunc: tt.f}}},
 			}
 			got, _, err := s.RegisterValidator(context.Background(), time.Now(), nil, "", "")
 			if err == nil {
@@ -151,10 +151,8 @@ func TestService_StreamHeaderAndGetMethod(t *testing.T) {
 		t.Fatal("Failed to create client connection", zap.Error(err))
 	}
 	defer conn.Close()
-	doneCh := make(chan struct{})
-	reconnectingCh := make(chan struct{})
 	relayClient := relaygrpc.NewRelayClient(conn)
-	c := &Client{lis.Addr().String(), conn, doneCh, reconnectingCh, relayClient}
+	c := &Client{lis.Addr().String(), conn, relayClient}
 	service := NewService(l, "test", "", "", c)
 
 	go service.StreamHeader(ctx, c)

--- a/api/service_test.go
+++ b/api/service_test.go
@@ -155,11 +155,7 @@ func TestService_StreamHeaderAndGetMethod(t *testing.T) {
 	relayClient := relaygrpc.NewRelayClient(conn)
 	service := NewService(l, "test", "", "", &Client{lis.Addr().String(), relayClient})
 
-	go func() {
-		if _, err := service.StreamHeader(ctx, relayClient); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	go service.StreamHeader(ctx, relayClient)
 
 	server := &Server{svc: service, logger: zap.NewNop(), listenAddress: "127.0.0.1:9090"}
 	go server.Start()

--- a/cmd/mev-relay-proxy/main.go
+++ b/cmd/mev-relay-proxy/main.go
@@ -41,6 +41,7 @@ var (
 func main() {
 	flag.Parse()
 	l := newLogger(_AppName, _BuildVersion)
+	defer l.Sync()
 	ctx, cancel := context.WithCancel(context.Background())
 	// init client connection
 	var (
@@ -89,6 +90,7 @@ func main() {
 	<-exit
 }
 func newLogger(appName, version string) *zap.Logger {
+
 	logLevel := zap.DebugLevel
 	var zapCore zapcore.Core
 	level := zap.NewAtomicLevel()

--- a/cmd/mev-relay-proxy/main.go
+++ b/cmd/mev-relay-proxy/main.go
@@ -53,7 +53,9 @@ func main() {
 		if err != nil {
 			l.Fatal("failed to create mev-relay-proxy client connection", zap.Error(err))
 		}
-		clients = append(clients, &api.Client{URL: url, RelayClient: relaygrpc.NewRelayClient(conn)})
+		doneCh := make(chan struct{})
+		reconnectCh := make(chan struct{})
+		clients = append(clients, &api.Client{URL: url, Conn: conn, Done: doneCh, Reconnect: reconnectCh, RelayClient: relaygrpc.NewRelayClient(conn)})
 		conns = append(conns, conn)
 	}
 	defer func() {

--- a/cmd/mev-relay-proxy/main.go
+++ b/cmd/mev-relay-proxy/main.go
@@ -74,6 +74,7 @@ func main() {
 		l.Warn("shutting down")
 		signal.Stop(shutdown)
 		cancel()
+		server.Stop()
 		close(exit)
 	}()
 

--- a/cmd/mev-relay-proxy/main.go
+++ b/cmd/mev-relay-proxy/main.go
@@ -50,13 +50,11 @@ func main() {
 	)
 	urls := strings.Split(*relaysGRPCURL, ",")
 	for _, url := range urls {
-		conn, err := grpc.Dial(url, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		conn, err := grpc.Dial(url, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 		if err != nil {
 			l.Fatal("failed to create mev-relay-proxy client connection", zap.Error(err))
 		}
-		doneCh := make(chan struct{})
-		reconnectCh := make(chan struct{})
-		clients = append(clients, &api.Client{URL: url, Conn: conn, Done: doneCh, Reconnect: reconnectCh, RelayClient: relaygrpc.NewRelayClient(conn)})
+		clients = append(clients, &api.Client{URL: url, Conn: conn, RelayClient: relaygrpc.NewRelayClient(conn)})
 		conns = append(conns, conn)
 	}
 	defer func() {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/bloXroute-Labs/relay-grpc v0.0.12
 	github.com/go-chi/chi/v5 v5.0.10
 	github.com/google/uuid v1.3.1
+	github.com/gorilla/mux v1.8.0
 	go.uber.org/zap v1.26.0
 	google.golang.org/grpc v1.60.1
 	google.golang.org/protobuf v1.31.0

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
 github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.0 h1:RtRsiaGvWxcwd8y3BiRZxsylPT8hLWZ5SPcfI+3IDNk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.0/go.mod h1:TzP6duP4Py2pHLVPPQp42aoYI92+PCrVotyR5e8Vqlk=
 github.com/holiman/uint256 v1.2.4 h1:jUc4Nk8fm9jZabQuqr2JzednajVmBpC+oiTiXZJEApU=


### PR DESCRIPTION
- Many times we have see that, requests are delayed as the first request waits for a response, or the first request succeeds while the second request remains unresponsive. To prevent the initial request from causing a blocking call, execute it in a separate goroutine. I hope This modification aims to improve overall speed and responsiveness.